### PR TITLE
feat(employee): add isActive flag to employee register and update logic

### DIFF
--- a/src/employee/dto/employee.dto.ts
+++ b/src/employee/dto/employee.dto.ts
@@ -44,6 +44,8 @@ export class UpdateEmployeeRegisterDto {
   })
   @IsEnum(EmployeeRegisterStatus)
   status: EmployeeRegisterStatus;
+  @ApiProperty()
+  isActive: boolean;
 }
 
 export class FindRegisterRequestsDto {

--- a/src/employee/employee.service.ts
+++ b/src/employee/employee.service.ts
@@ -13,7 +13,7 @@ import { NotificationService } from 'src/notification/notification.service';
 import { ServiceService } from 'src/service/service.service';
 import { User } from 'src/user/entities/user.entity';
 import { UserService } from 'src/user/user.service';
-import { FindOptionsWhere, Repository } from 'typeorm';
+import { FindOptionsWhere, Not, Repository } from 'typeorm';
 import {
   AddServiceDto,
   EmployeeRegisterDto,
@@ -149,8 +149,17 @@ export class EmployeeService {
     if (!business)
       throw new NotFoundException('Business register request not found');
 
+    await this.employeeRegisterRepo.update(
+      { id: Not(employeeRegister.id) }, // condition: exclude this ID
+      {
+        status: dto.status,
+        isActive: false,
+      },
+    );
+
     await this.employeeRegisterRepo.update(employeeRegister.id, {
       status: dto.status,
+      isActive: true,
     });
     await this.employeeRepo.update(employee.id, {
       business: { id: businessId },

--- a/src/employee/entities/employee-register.entity.ts
+++ b/src/employee/entities/employee-register.entity.ts
@@ -21,6 +21,9 @@ export class EmployeeRegister extends SharedColumn {
   })
   status: EmployeeRegisterStatus;
 
+  @Column({ default: false })
+  isActive: boolean;
+
   @Column({ nullable: true })
   description: string;
 }


### PR DESCRIPTION
Added isActive property to EmployeeRegister entity with default false.

Updated UpdateEmployeeRegisterDto to include isActive.

Updated EmployeeService to:

Set isActive: false for all other employee register records when updating one.

Set isActive: true for the updated record.

Imported Not from TypeORM to exclude specific records in the update.